### PR TITLE
Add parameter for whether a repo has an upstream

### DIFF
--- a/src/go/src/ebw/git/GitRepo.go
+++ b/src/go/src/ebw/git/GitRepo.go
@@ -10,7 +10,8 @@ import (
 type GitRepo struct {
 	*github.Repository
 
-	lastCommit *CommitInfo
+	lastCommit  *CommitInfo
+	hasUpstream bool
 }
 
 func (gr *GitRepo) GetLastCommit() *CommitInfo {
@@ -41,7 +42,9 @@ func FetchRepos(client *Client) ([]*GitRepo, error) {
 		if nil == err {
 			gr.lastCommit = lc
 		}
+		gr.hasUpstream = r.Fork
 		grs[i] = gr
+
 	}
 	return grs, nil
 }


### PR DESCRIPTION
The repository object has an isForked parameter, seems legit to just use this to check if a repo has an upstream?